### PR TITLE
Adding reordering to entry edit screen

### DIFF
--- a/fields/field.order_entries.php
+++ b/fields/field.order_entries.php
@@ -34,6 +34,14 @@
 		function canPrePopulate(){
 			return true;
 		}
+
+		function processRawFieldData($data, &$status, $simulate=false, $entry_id=null) {
+
+			Symphony::Database()->query("UPDATE tbl_entries_data_{$this->get('id')} SET value = (value + 1) WHERE value >= ".$data);
+			return array(
+				'value' => $data,
+			);
+		}
 		
 		function groupRecords($records){
 			


### PR DESCRIPTION
If the entry is updated from the entry edit page, it will change the order of all the other entries to match (like it does on the drag and drop)
