### PR TITLE
Fixed php fatal error on entries table

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -29,7 +29,7 @@
 				if ($section->getSortingOrder() !== 'asc' || !is_numeric($section->getSortingField())) return;
 				
 				$field = FieldManager::fetch($section->getSortingField());
-				if($field->get('type') !== 'order_entries') return;
+				if(!$field || $field->get('type') !== 'order_entries') return;
 				
 				Administration::instance()->Page->addElementToHead(
 					new XMLElement(


### PR DESCRIPTION
Extension throws php fatal error on entries table, if section is sorted by "Entry Order"-field and the field has since been removed from the section.

```
Fatal error: Call to a member function get() on a non-object in .../symphony-2.3/extensions/order_entries/extension.driver.php on line 32
```
