### PR TITLE
Added delegate calls for drag sorting handler

### DIFF
--- a/content/content.save.php
+++ b/content/content.save.php
@@ -10,6 +10,8 @@
 			
 		    if(!is_array($items) || empty($items)) exit;
 
+		    Symphony::ExtensionManager()->notifyMembers('EntryPreEdit', '/publish/edit/');
+
 			foreach($items as $entry_id => $position) {
 				$id = Symphony::Database()->fetchVar('id', 0, "SELECT id FROM tbl_entries_data_$field_id WHERE `entry_id` = '$entry_id' ORDER BY id ASC LIMIT 1");
 				if (is_null($id)) {
@@ -19,6 +21,8 @@
 					Symphony::Database()->query("DELETE FROM tbl_entries_data_$field_id WHERE `entry_id` = '$entry_id' AND `id` > '$id'");
 				}
 		    }
+
+		    Symphony::ExtensionManager()->notifyMembers('EntryPostEdit', '/publish/edit/');
 			
 			exit;
 		}


### PR DESCRIPTION
Hi, Nick!

I've added two lines of code to content.save.php, so that respective delegates would be called before and after sorting by dragging is handled. Apart from consistency considerations, this allows the cache to be cleared when sort order changes without explicitly saving the entry.

It feels like a temporary workaround, however. Is there any reason why you hadn't used the generic entry saving mechanism?
