### PR TITLE
Prevent duplicates in the DB

### DIFF
--- a/fields/field.order_entries.php
+++ b/fields/field.order_entries.php
@@ -177,7 +177,7 @@
 				  `entry_id` int(11) unsigned NOT NULL,
 				  `value` double default NULL,
 				  PRIMARY KEY  (`id`),
-				  KEY `entry_id` (`entry_id`),
+				  UNIQUE KEY `entry_id` (`entry_id`),
 				  KEY `value` (`value`)
 				) TYPE=MyISAM;"
 


### PR DESCRIPTION
On a rather busy system, I experienced issues from time to time with "double entries" in the entries table, i.e. entries having the same `entry_id`. That broke XML output (because an array occured where a string would've been fine).

I fixed that issue by making the `entry_id` a unique key. No problems anymore.
