### PR TITLE
New Delegate and Pagination fix

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -82,7 +82,9 @@
 
 	            //$config->remove('pagination_maximum_rows','symphony');
 	            //Set the pagination value to equal total entry count
-	            $config->set('pagination_maximum_rows',$count,'symphony');
+	            if(!is_null($count) && $count > 0){
+	            	$config->set('pagination_maximum_rows',$count,'symphony');
+	            }
 	            
 	        }
 


### PR DESCRIPTION
This change is to cater for the Configuration `pagination_maximum_rows` issue we always encounter. the current code saves the change back to the configuration file with pagination set to 99999 when a filer option is changed/set using Order Entries.

This code ads the AdjustPublishFiltering delegate which will temporarily override the config setting on backend page, only if the order entry field is present in the section and also IS the active filtering field. It does not save the pagination back to the config as before... what it does is count total entries in the section and use that value for the `pagination_maximum_rows` value in the Configuration object at runtime.
