### PR TITLE
Fixing problem when the page's html is changed by other extensions

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -68,15 +68,22 @@
 
 			if($callback['driver'] == 'publish' && $callback['context']['page'] == 'index') {
 				$contents = $context['oPage']->Contents->getChildren();
-				$form = $contents[0]->getChildrenByName('table');
-				$table = $form[0];
+				
+				// check every child, since the
+				// form may not always be the first element
+				foreach ($contents as $child) {
+					$form = $child->getChildrenByName('table');
+					$table = $form[0];
 
-				if(!empty($table)) {
-					$table->setAttribute('data-order-entries-id', $this->field_id);
-					$table->setAttribute('data-order-entries-direction', $this->direction);
+					if(!empty($table)) {
+						$table->setAttribute('data-order-entries-id', $this->field_id);
+						$table->setAttribute('data-order-entries-direction', $this->direction);
 
-					if($this->force_sort == 'yes') {
-						$table->setAttribute('data-order-entries-force', 'true');
+						if($this->force_sort == 'yes') {
+							$table->setAttribute('data-order-entries-force', 'true');
+						}
+						
+						break;
 					}
 				}
 			}


### PR DESCRIPTION
This fixes a compatibility problem with other extensions when they add extra html nodes into the content.

Form is not guaranteed to be the first child of content.

Checking every child resolve the issue.

Thanks to @beaubbe that found it.

---

I really think it's time that we update XMLElement in order to make search in its tree easier...
