### PR TITLE
Fix inconsistent behavior

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -76,7 +76,8 @@
 				// form may not always be the first element
 				foreach ($contents as $child) {
 					$form = $child->getChildrenByName('table');
-					$table = $form[0];
+					// use current here since the keys can change somehow
+					$table = current($form);
 
 					if(!empty($table)) {
 						$table->setAttribute('data-order-entries-id', $this->field_id);


### PR DESCRIPTION
@andrewminton found out that on some setup, `$form[0]` would not be
set. Somehow, the first item in the array was at key = 1

So this fix uses php's current method to get the firt item in the array.
