### PR TITLE
Add support for pagination of entries

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,3 +11,21 @@
 1. Add the "Entry Order" field to your section and tick the "Show column" box.
 2. **Click the column heading to sort table** by the Entry Order field to enable drag and drop.
 3. When ordered ascending, drag entries within the table and the orders will be re-saved.
+
+## Pagination
+
+As of version 2.1.4 Order entries has an additional pagination order per entry. Through this one can set a particular section to be paginated or not.
+
+When using normal pagination the extension makes sure that entries within the page start with the offset of that particular page. 
+For Example if you're on page 3 with 20 entries per page, the first entry will take a minimum index of 41. As this is the least possible to be after the last one of the previous page.
+
+## Filtered Views
+
+Since Filtering made it to the core, some problems have arisen in regards to Order Entries. In it's previous form filtering and re-ordering would reset the index of that particular sort to start from 1.
+This is not always the expected result, with the changes implemented in this version, the offset will start from the **minimum** index found in the entry.
+So if you're sorting entries which were numbered `4`, `5` and `6` they will keep the same index values when resorted.
+However if you are sorting `4`, `6` and `12` sorting would give the following indices; `4`, `5` and `6`.
+
+Note that if you plan to use the sorting values only within the filtered views, and use that within your data sources this change will not impact your workflow.
+
+Expect some further changes in the near future in regards to filtered views and support of multiple sort values for different filters.

--- a/assets/order_entries.publish.js
+++ b/assets/order_entries.publish.js
@@ -7,7 +7,7 @@
 	});
 
 	Symphony.Extensions.OrderEntries = function() {
-		var table, fieldId,	direction, oldSorting, newSorting;
+		var table, fieldId,	direction, oldSorting, newSorting, startValue;
 
 		var init = function() {
 			table = Symphony.Elements.contents.find('table');
@@ -30,6 +30,11 @@
 
 			// Process sort order
 			oldSorting = getState();
+			startValue = parseInt(table.find('.order-entries-item').eq(0).text());
+			var assumedStartValue = Symphony.Pagination['max-rows'] * (Symphony.Pagination['current'] - 1) + 1;
+			if (startValue == 0 || direction == 'asc' && startValue < assumedStartValue) {
+				startValue = assumedStartValue;
+			}
 			table.on('orderstop.orderable', processState);
 		};
 
@@ -57,10 +62,12 @@
 						var items = table.find('.order-entries-item');
 						items.each(function(index) {
 							if(direction == 'asc') {
-								$(this).text(index + 1);
+								$(this).text(index + startValue);
 							}
 							else {
-								$(this).text(items.length - index);
+								var largest = startValue;
+								if ( items.length > largest ) largest = items.length;
+								$(this).text(largest - index);
 							}
 						});
 					},
@@ -80,10 +87,12 @@
 
 			states = items.map(function(index) {
 				if(direction == 'asc') {
-					return this.name + '=' + (index + 1);
+					return this.name + '=' + (index + startValue);
 				}
 				else {
-					return this.name + '=' + (items.length - index);
+					var largest = startValue;
+					if ( items.length > largest ) largest = items.length;
+					return this.name + '=' + (largest - index);
 				}
 			}).get().join('&');
 

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -54,7 +54,9 @@
 					
 						// Initialise manual ordering
 						$this->addComponents();
-						$this->disablePagination();
+						if ($field->get('disable_pagination') == 'yes'){
+							$this->disablePagination();
+						}
 					}
 				}
 			}
@@ -97,6 +99,19 @@
 		 * Add components for manual entry ordering
 		 */
 		public function addComponents() {
+
+			$pagination = array(
+				'max-rows' => Symphony::Configuration()->get('pagination_maximum_rows', 'symphony'),
+				'current' => (isset($_REQUEST['pg']) && is_numeric($_REQUEST['pg']) ? max(1, intval($_REQUEST['pg'])) : 1)
+				// 'total' => $pgmax
+			);
+
+			Administration::instance()->Page->addElementToHead(
+				new XMLElement('script', 'Symphony.Pagination='.json_encode($pagination), array(
+					'type' => 'text/javascript'
+				))				
+			);
+
 			Administration::instance()->Page->addScriptToHead(
 				URL . '/extensions/order_entries/assets/order_entries.publish.js'
 			);
@@ -147,6 +162,15 @@
 					ALTER TABLE `tbl_fields_order_entries`
 					ADD `hide` enum('yes','no')
 					DEFAULT 'no'
+				");
+			}
+
+			// Prior version 2.1.4
+			if(version_compare($previousVersion, '2.1.4', '<')) {
+				$status[] = Symphony::Database()->query("
+					ALTER TABLE `tbl_fields_order_entries`
+					ADD `disable_pagination` enum('yes','no')
+					DEFAULT 'yes'
 				");
 			}
 

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -18,6 +18,9 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="2.1.4" date="2015-01-21" min="2.4" max='2.6.x'>
+			- Add Disable Pagination Option
+		</release>
 		<release version="2.1.3" date="2014-07-13" min="2.4">
 			- Fixed the login page being crashed
 		</release>

--- a/fields/field.order_entries.php
+++ b/fields/field.order_entries.php
@@ -107,6 +107,17 @@
 
 			$label->setValue(__('%s Force manual sorting', array($input->generate())));
 			$div->appendChild($label);
+
+			$label = Widget::Label();
+			$label->setAttribute('class', 'column');
+			$input = Widget::Input("fields[{$order}][disable_pagination]", 'yes', 'checkbox');
+
+			if($this->get('disable_pagination') == 'yes') {
+				$input->setAttribute('checked', 'checked');
+			}
+
+			$label->setValue(__('%s Disable Pagination', array($input->generate())));
+			$div->appendChild($label);
 			$wrapper->appendChild($div);
 
 			// Display options
@@ -143,6 +154,7 @@
 
 			$fields['field_id'] = $id;
 			$fields['force_sort'] = $this->get('force_sort');
+			$fields['disable_pagination'] = $this->get('disable_pagination');
 			$fields['hide'] = $this->get('hide');
 
 			// Update section's sorting field


### PR DESCRIPTION
Makes pagination optional for Entry Orders, was previously forced for Order Entries to work properly, thus closes #17 

Also includes a fix to support filtered views mentioned in #43. This fix keeps the smallest value and re-orders the values after that. It's possibly not a complete fix maybe @andrewminton can give some feedback in that regard.

I'm also planning a separate PR which might be somewhat more comprehensive to allow distinct sorting for filtered views, however that might require some further UI & DB changes.

Note. pull request done against master as integration is not updated.