### PR TITLE
Filtering

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,3 +11,21 @@
 1. Add the "Entry Order" field to your section and tick the "Show column" box.
 2. **Click the column heading to sort table** by the Entry Order field to enable drag and drop.
 3. When ordered ascending, drag entries within the table and the orders will be re-saved.
+
+## Pagination
+
+As of version 2.1.4 Order entries has an additional pagination order per entry. Through this one can set a particular section to be paginated or not.
+
+When using normal pagination the extension makes sure that entries within the page start with the offset of that particular page. 
+For Example if you're on page 3 with 20 entries per page, the first entry will take a minimum index of 41. As this is the least possible to be after the last one of the previous page.
+
+## Filtered Views
+
+Since Filtering made it to the core, some problems have arisen in regards to Order Entries. In it's previous form filtering and re-ordering would reset the index of that particular sort to start from 1.
+This is not always the expected result, with the changes implemented in this version, the offset will start from the **minimum** index found in the entry.
+So if you're sorting entries which were numbered `4`, `5` and `6` they will keep the same index values when resorted.
+However if you are sorting `4`, `6` and `12` sorting would give the following indices; `4`, `5` and `6`.
+
+Note that if you plan to use the sorting values only within the filtered views, and use that within your data sources this change will not impact your workflow.
+
+Expect some further changes in the near future in regards to filtered views and support of multiple sort values for different filters.

--- a/README.markdown
+++ b/README.markdown
@@ -28,4 +28,13 @@ However if you are sorting `4`, `6` and `12` sorting would give the following in
 
 Note that if you plan to use the sorting values only within the filtered views, and use that within your data sources this change will not impact your workflow.
 
-Expect some further changes in the near future in regards to filtered views and support of multiple sort values for different filters.
+## Filtered Ordering
+
+Order Entries now supports an option to filter entries and order them separately.
+To activate this functionality you have to select which fields you would like to use for filtering from within the settings panel.
+Once saved, filtered views will have separate orders depending on your settings.
+
+It is very important to note that with version 2.2 the "Filter value" used within the publish page matches whatever you put in your datasource.
+Sorting and order values are determined from the matching datasource parameter.
+If in the publish page was filtered by "Home" and your datasource filter says "home" the datasource ordering outputs will not match.
+An update to tackle this more comprehensively will be released shortly.

--- a/assets/order_entries.publish.js
+++ b/assets/order_entries.publish.js
@@ -7,7 +7,7 @@
 	});
 
 	Symphony.Extensions.OrderEntries = function() {
-		var table, fieldId,	direction, oldSorting, newSorting;
+		var table, fieldId,	direction, oldSorting, newSorting, startValue;
 
 		var init = function() {
 			table = Symphony.Elements.contents.find('table');
@@ -30,6 +30,11 @@
 
 			// Process sort order
 			oldSorting = getState();
+			startValue = parseInt(table.find('.order-entries-item').eq(0).text());
+			var assumedStartValue = Symphony.Pagination['max-rows'] * (Symphony.Pagination['current'] - 1) + 1;
+			if (startValue == 0 || direction == 'asc' && startValue < assumedStartValue) {
+				startValue = assumedStartValue;
+			}
 			table.on('orderstop.orderable', processState);
 		};
 
@@ -57,10 +62,12 @@
 						var items = table.find('.order-entries-item');
 						items.each(function(index) {
 							if(direction == 'asc') {
-								$(this).text(index + 1);
+								$(this).text(index + startValue);
 							}
 							else {
-								$(this).text(items.length - index);
+								var largest = startValue;
+								if ( items.length > largest ) largest = items.length;
+								$(this).text(largest - index);
 							}
 						});
 					},
@@ -80,10 +87,12 @@
 
 			states = items.map(function(index) {
 				if(direction == 'asc') {
-					return this.name + '=' + (index + 1);
+					return this.name + '=' + (index + startValue);
 				}
 				else {
-					return this.name + '=' + (items.length - index);
+					var largest = startValue;
+					if ( items.length > largest ) largest = items.length;
+					return this.name + '=' + (largest - index);
 				}
 			}).get().join('&');
 

--- a/assets/order_entries.publish.js
+++ b/assets/order_entries.publish.js
@@ -7,12 +7,21 @@
 	});
 
 	Symphony.Extensions.OrderEntries = function() {
-		var table, fieldId,	direction, oldSorting, newSorting, startValue;
+		var table, fieldId,	direction, oldSorting, newSorting, startValue, filters;
 
 		var init = function() {
 			table = Symphony.Elements.contents.find('table');
 			fieldId = table.attr('data-order-entries-id');
 			direction = table.attr('data-order-entries-direction');
+			filters = Symphony.Context.get('env').filters;
+
+			// convert filters into a query string
+			if (typeof(filters)!== 'undefined'){
+				filters = {"filters":filters};
+				filters = '&' + $.param(filters)
+			} else {
+				filters = '';
+			}
 
 			// Add help
 			Symphony.Elements.breadcrumbs.append('<p class="inactive"><span>– ' + Symphony.Language.get('drag to reorder') + '</span></p>');
@@ -54,11 +63,11 @@
 				$.ajax({
 					type: 'GET',
 					url: Symphony.Context.get('symphony') + '/extension/order_entries/save/',
-					data: newSorting + '&field=' + fieldId + '&' + Symphony.Utilities.getXSRF(true),
+					data: newSorting + '&field=' + fieldId + filters + '&' + Symphony.Utilities.getXSRF(true),
 					success: function() {
 						oldSorting = newSorting;
 
-						// Update indexes
+					// Update indexes
 						var items = table.find('.order-entries-item');
 						items.each(function(index) {
 							if(direction == 'asc') {

--- a/assets/order_entries.publish.js
+++ b/assets/order_entries.publish.js
@@ -39,8 +39,8 @@
 
 			// Process sort order
 			oldSorting = getState();
-			startValue = parseInt(table.find('.order-entries-item').eq(0).text());
-			var assumedStartValue = Symphony.Pagination['max-rows'] * (Symphony.Pagination['current'] - 1) + 1;
+			startValue = parseInt(table.find('.order-entries-item').eq(0).text(),10);
+			var assumedStartValue = Symphony.Context.get('env').pagination['max-rows'] * (Symphony.Context.get('env').pagination['current'] - 1) + 1;
 			if (startValue == 0 || direction == 'asc' && startValue < assumedStartValue) {
 				startValue = assumedStartValue;
 			}

--- a/assets/order_entries.publish.js
+++ b/assets/order_entries.publish.js
@@ -16,7 +16,7 @@
 			filters = Symphony.Context.get('env').filters;
 
 			// convert filters into a query string
-			if (typeof(filters)!== 'undefined'){
+			if (filters){
 				filters = {"filters":filters};
 				filters = '&' + $.param(filters)
 			} else {

--- a/content/content.save.php
+++ b/content/content.save.php
@@ -7,11 +7,38 @@
 		public function view(){
 			$field_id = General::sanitize($_GET['field']);
 			$items = $_GET['items'];
+			$filters = $_GET['filters'];
 
 			if(!is_array($items) || empty($items)) {
 				$this->_Result['error'] = __('No items provided');
 				$this->generate();
 			};
+
+			$where = '';
+
+			$field = FieldManager::fetch($field_id);
+			$filterableFields = explode(',', $field->get('filtered_fields'));
+			$section_id = $field->get('parent_section');
+
+			if(!is_array($filters) && empty($filters)) {
+				$filters = array();
+			}
+
+			//set change the field name with the field id for each filter
+			if(!empty($filterableFields)) {
+
+				// check if the filters are related to the entry order being saved
+				foreach ($filters as $field_name => $value) {
+					$filtered_field_id = FieldManager::fetchFieldIDFromElementName($field_name,$section_id);
+					if (in_array($filtered_field_id, $filterableFields)){
+						$filters[$filtered_field_id] = $value;
+
+					}
+					unset($filters[$field_name]);
+				}
+
+				$where = $field->buildFilteringSQL($filters);
+			}
 
 			/**
 			 * Just prior to reordering entries
@@ -28,25 +55,36 @@
 				$id = Symphony::Database()->fetchVar('id', 0, "
 					SELECT id
 					FROM tbl_entries_data_$field_id
-					WHERE `entry_id` = '$entry_id'
+					WHERE `entry_id` = '$entry_id' {$where}
 					ORDER BY id ASC LIMIT 1
 				");
 
 				if(is_null($id)) {
+					$fields = '';
+					$values = '';
+
+					//add the filtered params if available (default set to null)
+					foreach ($filterableFields as $key => $filterable_field) {
+						if (isset($filters[$filterable_field])){
+							$fields .= " ,field_{$filterable_field}";
+							$values .= " ,'{$filters[$filterable_field]}'";
+						}
+					}
+
 					Symphony::Database()->query("
-						INSERT INTO tbl_entries_data_$field_id (entry_id, value)
-						VALUES ('$entry_id', '$position')
+						INSERT INTO tbl_entries_data_$field_id (entry_id, value{$fields})
+						VALUES ('$entry_id', '$position'{$values})
 					");
 				}
 				else {
 					Symphony::Database()->query("
 						UPDATE tbl_entries_data_$field_id
 						SET `value`='$position'
-						WHERE `entry_id` = '$entry_id'
+						WHERE `entry_id` = '$entry_id' {$where}
 					");
 					Symphony::Database()->query("
 						DELETE FROM tbl_entries_data_$field_id
-						WHERE `entry_id` = '$entry_id'
+						WHERE `entry_id` = '$entry_id' {$where}
 						AND `id` > '$id'
 					");
 				}

--- a/content/content.save.php
+++ b/content/content.save.php
@@ -31,8 +31,7 @@
 				foreach ($filters as $field_name => $value) {
 					$filtered_field_id = FieldManager::fetchFieldIDFromElementName($field_name,$section_id);
 					if (in_array($filtered_field_id, $filterableFields)){
-						$filters[$filtered_field_id] = General::sanitize($value);
-
+						$filters[$filtered_field_id] = strtolower(General::sanitize($value));
 					}
 					unset($filters[$field_name]);
 				}

--- a/content/content.save.php
+++ b/content/content.save.php
@@ -31,7 +31,7 @@
 				foreach ($filters as $field_name => $value) {
 					$filtered_field_id = FieldManager::fetchFieldIDFromElementName($field_name,$section_id);
 					if (in_array($filtered_field_id, $filterableFields)){
-						$filters[$filtered_field_id] = $value;
+						$filters[$filtered_field_id] = General::sanitize($value);
 
 					}
 					unset($filters[$field_name]);

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -66,6 +66,7 @@
 
 			} else {
 				$filters = $this->dsFilters;
+				if (empty($filters)) return array();
 
 				// check if the filters are used for entry ordering otherwise remove from list
 				foreach ($filters as $filtered_field_id => $value) {

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -59,7 +59,8 @@
 				foreach ($filters as $field_name => $value) {
 					$filtered_field_id = FieldManager::fetchFieldIDFromElementName($field_name,$section_id);
 					if (in_array($filtered_field_id, $filterableFields)){
-						$filters[$filtered_field_id] = $value;
+						//ensuring that capitalization will never be an issue
+						$filters[$filtered_field_id] = strtolower($value);
 					}
 					unset($filters[$field_name]);
 				}

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -161,7 +161,7 @@
 			Administration::instance()->Page->addElementToHead(
 				new XMLElement('script', 'Symphony.Pagination='.json_encode($pagination), array(
 					'type' => 'text/javascript'
-				))				
+				))
 			);
 
 			Administration::instance()->Page->addScriptToHead(

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -152,16 +152,32 @@
 		 */
 		public function addComponents() {
 
+			// get pagination data
 			$pagination = array(
 				'max-rows' => Symphony::Configuration()->get('pagination_maximum_rows', 'symphony'),
 				'current' => (isset($_REQUEST['pg']) && is_numeric($_REQUEST['pg']) ? max(1, intval($_REQUEST['pg'])) : 1)
-				// 'total' => $pgmax
 			);
 
+
+			// get filter data
+			$filters = $_REQUEST['filter'];
+			if (is_array($filters)){
+				$generatedFilters = array();
+				foreach ($filters as $field => $value) {
+					$generatedFilters[$field] = $value;
+				}
+			}
+
+			// add pagination and filter data into symphony context if Symphony does not provide it
 			Administration::instance()->Page->addElementToHead(
-				new XMLElement('script', 'Symphony.Pagination='.json_encode($pagination), array(
-					'type' => 'text/javascript'
-				))
+				new XMLElement(
+					'script', 
+					'if (! Symphony.Context.get(\'env\').pagination) Symphony.Context.get(\'env\').pagination='.json_encode($pagination).';' .
+					'if (! Symphony.Context.get(\'env\').filters) Symphony.Context.get(\'env\').filters='.json_encode($generatedFilters).';'
+					, array(
+						'type' => 'text/javascript'
+					)
+				)
 			);
 
 			Administration::instance()->Page->addScriptToHead(

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -54,7 +54,9 @@
 					
 						// Initialise manual ordering
 						$this->addComponents();
-						$this->disablePagination();
+						if ($field->get('disable_pagination') == 'yes'){
+							$this->disablePagination();
+						}
 					}
 				}
 			}
@@ -97,6 +99,19 @@
 		 * Add components for manual entry ordering
 		 */
 		public function addComponents() {
+
+			$pagination = array(
+				'max-rows' => Symphony::Configuration()->get('pagination_maximum_rows', 'symphony'),
+				'current' => (isset($_REQUEST['pg']) && is_numeric($_REQUEST['pg']) ? max(1, intval($_REQUEST['pg'])) : 1)
+				// 'total' => $pgmax
+			);
+
+			Administration::instance()->Page->addElementToHead(
+				new XMLElement('script', 'Symphony.Pagination='.json_encode($pagination), array(
+					'type' => 'text/javascript'
+				))				
+			);
+
 			Administration::instance()->Page->addScriptToHead(
 				URL . '/extensions/order_entries/assets/order_entries.publish.js'
 			);
@@ -147,6 +162,15 @@
 					ALTER TABLE `tbl_fields_order_entries`
 					ADD `hide` enum('yes','no')
 					DEFAULT 'no'
+				");
+			}
+
+			// Prior version 2.1.4
+			if(version_compare($previousVersion, '2.1.4', '<')) {
+				$status[] = Symphony::Database()->query("
+					ALTER TABLE `tbl_fields_order_entries`
+					ADD `disable_pagination` enum('yes','no')
+					DEFAULT 'yes'
 				");
 			}
 

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -18,6 +18,9 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="2.1.4" date="2015-01-21" min="2.4" max='2.6.x'>
+			- Add Disable Pagination Option
+		</release>
 		<release version="2.1.3" date="2014-07-13" min="2.4">
 			- Fixed the login page being crashed
 		</release>

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -18,6 +18,9 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="2.2" date="2015-01-22" min="2.5" max='2.6.x'>
+			- Add contextual Ordering using backend/frontend filters
+		</release>
 		<release version="2.1.4" date="2015-01-21" min="2.4" max='2.6.x'>
 			- Add Disable Pagination Option
 		</release>

--- a/fields/field.order_entries.php
+++ b/fields/field.order_entries.php
@@ -107,6 +107,17 @@
 
 			$label->setValue(__('%s Force manual sorting', array($input->generate())));
 			$div->appendChild($label);
+
+			$label = Widget::Label();
+			$label->setAttribute('class', 'column');
+			$input = Widget::Input("fields[{$order}][disable_pagination]", 'yes', 'checkbox');
+
+			if($this->get('disable_pagination') == 'yes') {
+				$input->setAttribute('checked', 'checked');
+			}
+
+			$label->setValue(__('%s Disable Pagination', array($input->generate())));
+			$div->appendChild($label);
 			$wrapper->appendChild($div);
 
 			// Display options
@@ -143,6 +154,7 @@
 
 			$fields['field_id'] = $id;
 			$fields['force_sort'] = $this->get('force_sort');
+			$fields['disable_pagination'] = $this->get('disable_pagination');
 			$fields['hide'] = $this->get('hide');
 
 			// Update section's sorting field

--- a/fields/field.order_entries.php
+++ b/fields/field.order_entries.php
@@ -138,6 +138,91 @@
 			$this->appendShowColumnCheckbox($div);
 			$fieldset->appendChild($div);
 			$wrapper->appendChild($fieldset);
+
+			//filtered orders
+
+			$fieldset = new XMLElement('fieldset');
+
+			$div = new XMLElement('h3', __('Filtered Ordering'));
+			$fieldset->appendChild($div);
+
+			$section = SectionManager::fetch($this->get('parent_section'));
+			if (!is_object($section)){
+				// you need to save first
+				$div = new XMLElement('p', __('You have to save this field before you can add filtered ordering'));
+				$fieldset->appendChild($div);
+			} else {
+				$fields = $section->fetchFields();
+
+				$options = array();
+
+				$filteredFields = $this->get('filtered_fields');
+				if (!is_array($filteredFields)){
+					$filteredFields = explode(',', $filteredFields);
+				}
+
+				if (is_array($fields)) {
+					foreach ($fields as $field) {
+						$selected = in_array($field->get('id'), $filteredFields);
+						$options[] = array($field->get('id'),$selected,$field->get('label'));
+					}
+				}
+
+				$label = Widget::Label(__('Fields'));
+				$label->appendChild(
+					Widget::Select("fields[{$order}][filtered_fields][]", $options, array(
+						'multiple' => 'multiple',
+						'data-required' => 'false'
+					))
+				);
+
+				$fieldset->appendChild($label);
+
+			}
+			
+			$wrapper->appendChild($fieldset);
+
+
+		}
+
+		private function updateFilterTable(){
+			$filteredFields = $this->get('filtered_fields');
+			if (!is_array($filteredFields)){
+				$filteredFields = explode(',', $filteredFields);
+			}
+
+			$orderFieldId = $this->get('id');
+
+			// fetch existing table schema
+			$currentFilters = Symphony::Database()->fetchCol('Field',"SHOW COLUMNS FROM tbl_entries_data_{$orderFieldId} WHERE Field like 'field_%';");
+						
+			//change the value format to match the filtered fields stored
+			foreach ($currentFilters as $key => $value) {
+				$currentFilters[$key] = substr($value, 6);
+			}
+
+			$newFilters = array_diff($filteredFields, $currentFilters);
+			$removedFilters = array_diff($currentFilters, $filteredFields);
+
+			foreach ($removedFilters as $key => $field_id) {
+				Symphony::Database()->query("ALTER TABLE `tbl_entries_data_{$orderFieldId}` DROP COLUMN `field_{$field_id}`");
+			}
+
+			foreach ($newFilters as $key => $field_id) {
+				//maybe in the future fields can give supported filters until then using a varchar for flexibility
+				$fieldtype = "varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL";
+
+				Symphony::Database()->query("ALTER TABLE `tbl_entries_data_{$orderFieldId}` ADD COLUMN `field_{$field_id}`{$fieldtype}");
+			}
+
+			if (!empty($newFilters) || !empty($removedFilters)){
+				$fields = '';
+				foreach ($filteredFields as $field_id) {
+					$fields .= ",`field_{$field_id}` ";
+				}
+				Symphony::Database()->query("ALTER TABLE `tbl_entries_data_{$orderFieldId}` DROP INDEX `unique`;");
+				Symphony::Database()->query("ALTER TABLE `tbl_entries_data_{$orderFieldId}` ADD UNIQUE `unique`(`entry_id` {$fields});");
+			}
 		}
 
 		function commit() {
@@ -155,6 +240,7 @@
 			$fields['field_id'] = $id;
 			$fields['force_sort'] = $this->get('force_sort');
 			$fields['disable_pagination'] = $this->get('disable_pagination');
+			$fields['filtered_fields'] = implode(',', $this->get('filtered_fields'));
 			$fields['hide'] = $this->get('hide');
 
 			// Update section's sorting field
@@ -162,6 +248,8 @@
 				$section = SectionManager::fetch($this->get('parent_section'));
 				$section->setSortingField($id);
 			}
+
+			$this->updateFilterTable();
 
 			Symphony::Database()->query("DELETE FROM `tbl_fields_".$this->handle()."` WHERE `field_id` = '$id' LIMIT 1");
 			return Symphony::Database()->insert($fields, 'tbl_fields_' . $this->handle());
@@ -228,7 +316,7 @@
 					`entry_id` int(11) unsigned NOT null,
 					`value` double default null,
 					PRIMARY KEY  (`id`),
-					UNIQUE KEY `entry_id` (`entry_id`),
+					UNIQUE KEY `unique` (`entry_id`),
 					KEY `value` (`value`)
 				) TYPE=MyISAM;
 			");
@@ -252,22 +340,113 @@
 			return true;
 		}
 
+		public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC') {
+			
+			$filterableFields = explode(',', $this->get('filtered_fields'));
+			$section_id = $this->get('parent_section');
+
+			$orderEntriesExtension = ExtensionManager::create('order_entries');
+			$filters = $orderEntriesExtension->getFilters($filterableFields,$section_id);
+
+			$filteringParams = $this->buildFilteringSQL($filters,'`ed`.');
+
+			if (in_array(strtolower($order), array('random', 'rand'))) {
+				$sort = 'ORDER BY RAND()';
+			} else {
+				$joins .= "LEFT OUTER JOIN `tbl_entries_data_".$this->get('id')."` AS `ed` ON (`e`.`id` = `ed`.`entry_id`{$filteringParams}) ";
+				$sort = 'ORDER BY `ed`.`value` ' . $order;
+			}
+		}
+
+		public function buildFilteringSQL($filters,$prefix =''){
+
+			$filterableFields = $this->get('filtered_fields');
+
+			//no filters no sql to add
+			if (empty($filterableFields)) return "";
+
+			$filterableFields = explode(',', $filterableFields);
+
+			$where = '' ;
+
+			foreach ($filterableFields as $key => $filterable_field) {
+				if (isset($filters[$filterable_field])){
+					$where .= " AND {$prefix}field_{$filterable_field} = '{$filters[$filterable_field]}'";
+				} else {						
+					$where .= " AND {$prefix}field_{$filterable_field} is NULL";
+				}
+			}
+
+			return $where;
+		}
+
+		private function getOrderValue($data){
+
+			$filterableFields = $this->get('filtered_fields');
+
+			//there are no filters to apply so should just be a single value
+			if (empty($filterableFields)) return $data['value'];
+
+			$filterableFields = explode(',', $filterableFields);
+			$section_id = $this->get('parent_section');
+
+			$orderEntriesExtension = ExtensionManager::create('order_entries');
+			$filters = $orderEntriesExtension->getFilters($filterableFields,$section_id);
+
+
+			if (!is_array($data['value'])){
+				foreach ($data as $key => $value) {
+					$data[$key] = array($value);
+				}
+			}
+
+			if (is_array($data['value'])){
+				$keys = array_keys($data['value']);
+
+				foreach ($filterableFields as $filtered_field_id) {
+					$filter = $filters[$filtered_field_id];
+					$matchingKeys = array_search($filter, $data['field_' . $filtered_field_id]);
+
+					if (empty($matchingKeys) && !is_int($matchingKeys)){
+						$matchingKeys = array();
+					} else if (!is_array($matchingKeys)) {
+						$matchingKeys = array($matchingKeys);
+					}
+
+					//intersect the original keys with the filtered ones which match the search - should leave one or no items
+					$keys = array_intersect($keys, $matchingKeys);
+				}
+
+				if ( empty($keys) ){
+					//this view is not sorted
+					return 0;
+				} else {
+					return $data['value'][current($keys)];
+				}
+			} else {
+				return 0;
+			}
+		}
+
 		public function prepareTableValue($data, XMLElement $link = null) {
+
+			$orderValue = $this->getOrderValue($data);
+
 			if(!$link) {
-				return sprintf('<span class="order-entries-item">%d</span>', $data['value']);
+				return sprintf('<span class="order-entries-item">%d</span>', $orderValue);
 			}
 			else {
-				$link->setValue($data['value']);
+				$link->setValue($orderValue);
 				return $link->generate();
 			}
 		}
 
 		public function appendFormattedElement(XMLElement &$wrapper, $data, $encode = false, $mode = null, $entry_id = null) {
-			$wrapper->appendChild(new XMLElement($this->get('element_name'), $data['value']));
+			$wrapper->appendChild(new XMLElement($this->get('element_name'), $this->getOrderValue($data) ));
 		}
 
 		public function getParameterPoolValue(Array $data) {
-			return $data['value'];
+			return $this->getOrderValue($data);
 		}
 
 	}

--- a/fields/field.order_entries.php
+++ b/fields/field.order_entries.php
@@ -256,7 +256,7 @@
 		}
 
 		function displayPublishPanel(&$wrapper, $data = null, $flagWithError = null, $fieldnamePrefix = null, $fieldnamePostfix = null) {
-			$value = $data['value'];
+			$value = $this->getOrderValue($data);
 
 			$label = Widget::Label($this->get('label'));
 			if($this->get('required') != 'yes') $label->appendChild(new XMLElement('i', __('Optional')));
@@ -405,7 +405,12 @@
 
 				foreach ($filterableFields as $filtered_field_id) {
 					$filter = $filters[$filtered_field_id];
-					$matchingKeys = array_search($filter, $data['field_' . $filtered_field_id]);
+
+					if (isset($data['field_' . $filtered_field_id])){
+						$matchingKeys = array_search($filter, $data['field_' . $filtered_field_id]);
+					} else {
+						$matchingKeys = array();
+					}
 
 					if (empty($matchingKeys) && !is_int($matchingKeys)){
 						$matchingKeys = array();

--- a/fields/field.order_entries.php
+++ b/fields/field.order_entries.php
@@ -235,12 +235,16 @@
 				return false;
 			}
 
+			$filteredFields = $this->get('filtered_fields');
+			if (!isset($filteredFields))
+				$filteredFields = array();
+
 			$fields = array();
 
 			$fields['field_id'] = $id;
 			$fields['force_sort'] = $this->get('force_sort');
 			$fields['disable_pagination'] = $this->get('disable_pagination');
-			$fields['filtered_fields'] = implode(',', $this->get('filtered_fields'));
+			$fields['filtered_fields'] = implode(',', $filteredFields);
 			$fields['hide'] = $this->get('hide');
 
 			// Update section's sorting field

--- a/fields/field.order_entries.php
+++ b/fields/field.order_entries.php
@@ -40,7 +40,26 @@
 			$status = self::__OK__;
 			$increment_subsequent_order = false;
 
+			$filters = Symphony::Database()->fetchCol('Field',"SHOW COLUMNS FROM tbl_entries_data_{$this->get('id')} WHERE Field like 'field_%';");
+			// for now if there are any filters completely ignore any override.
+			if (!empty($filters)){
+				$filterString = implode(',', $filters);
+				$current_values = Symphony::Database()->fetch("
+					SELECT value, {$filterString}
+					FROM tbl_entries_data_{$this->get('id')}
+					WHERE entry_id=".$entry_id."
+				");
+				$result= array();
+				foreach ($current_values as $key => $row) {
+					foreach ($row as $col => $value) {
+						$result[$col][$key] = $value;
+					}
+				}
+				return $result;
+			}
+
 			if($entry_id) {
+
 				$new_value = $data;
 				$current_value = Symphony::Database()->fetchVar("value", 0, "
 					SELECT value


### PR DESCRIPTION
This introducing Order Filtering where you can have specific orders for filtered views. These orders can be output to the frontend by having a "Matching" datasource filter on the same parameter combination. 

If the filters within the publish filtering and the datasource are not an exact match, the ordering will not work as expected. Trying to see what is the best way to approach this to make further improvements.

This change should be compatible with 2.6.x, possibly lower.