### PR TITLE
fix order xml value

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -37,4 +37,18 @@ Once saved, filtered views will have separate orders depending on your settings.
 It is very important to note that with version 2.2 the "Filter value" used within the publish page matches whatever you put in your datasource.
 Sorting and order values are determined from the matching datasource parameter.
 If in the publish page was filtered by "Home" and your datasource filter says "home" the datasource ordering outputs will not match.
-An update to tackle this more comprehensively will be released shortly.
+
+Note: If you set filtered ordering, and within the backend no filters unset all sorting is done without any backend filters, and your datasource contains a filter for the same field as 'filtered ordering' no ordering will take place. As there are no values set with the backend filters matching the ones in your datasource.
+
+### Example Use Case
+
+You have been asked to design a schema for a cooking website. 
+Where each recipie has a number ingredients, thus you link your ingredients to your recipes using an association field.
+The client has also asked to be able to do a dedicated page per ingredient showing the suggested recipies, and they want to order all the supported recipes manually.
+
+Within your recipes section, you add a 'filtered ordering' on the 'ingredients' field
+This will create a distinct sort order for each ingredient when filtered within your backend.
+
+Thus the recipe 'Spagetti Bolognese' can be in 1st place for 'spagetti', 2nd place for 'tomato sauce' and 4th place for 'minced meat'. 
+Whilst 'lasagna' could be in 3rd place for 'tomato sauce' and 3rd place for 'minced meat'. 
+At the same time in the general recipie classification (no filters) 'Spagetti Bolognese' ranks 5th and 'Lasagna' 15th.

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -60,7 +60,7 @@
 					$filtered_field_id = FieldManager::fetchFieldIDFromElementName($field_name,$section_id);
 					if (in_array($filtered_field_id, $filterableFields)){
 						//ensuring that capitalization will never be an issue
-						$filters[$filtered_field_id] = strtolower($value);
+						$filters[$filtered_field_id] = strtolower(General::sanitize($value));
 					}
 					unset($filters[$field_name]);
 				}
@@ -73,6 +73,8 @@
 				foreach ($filters as $filtered_field_id => $value) {
 					if (!in_array($filtered_field_id, $filterableFields)){
 						unset($filters[$filtered_field_id]);
+					} else {
+						$filters[$filtered_field_id] = strtolower(General::sanitize($value));
 					}
 				}
 

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -105,7 +105,7 @@
 						$this->force_sort = $field->get('force_sort');
 						$this->field_id = $field->get('id');
 						$this->direction = $section->getSortingOrder();
-					
+
 						// Initialise manual ordering
 						$this->addComponents();
 						if ($field->get('disable_pagination') == 'yes'){
@@ -154,10 +154,13 @@
 							$tr = $tbody->getChildByName('tr',0);
 
 								$entry_id = str_replace('id-', '', $tr->getAttribute('id'));
-								$entry = current(EntryManager::fetch($entry_id));
-								$data = $entry->getData($this->field_id);
-								$order = $field->getParameterPoolValue($data);
-								$tr->setAttribute('data-order',$order);
+
+								if ($entry_id){
+									$entry = current(EntryManager::fetch($entry_id));
+									$data = $entry->getData($this->field_id);
+									$order = $field->getParameterPoolValue($data);
+									$tr->setAttribute('data-order',$order);
+								}
 						}
 						
 						break;
@@ -266,7 +269,6 @@
 				$status[] = Symphony::Database()->query("
 					ALTER TABLE `tbl_fields_order_entries`
 					ADD `filtered_fields` varchar(255) DEFAULT NULL
-					DEFAULT NULL
 				");
 
 				$fields =  Symphony::Database()->fetchCol('field_id',"SELECT field_id FROM `tbl_fields_order_entries`");
@@ -306,7 +308,8 @@
 					`disable_pagination` enum('yes','no') default 'no',
 					`filtered_fields` varchar(255) DEFAULT NULL,
 					PRIMARY KEY  (`id`),
-					UNIQUE KEY `field_id` (`field_id`)
+					UNIQUE KEY `field_id` (`field_id`),
+					UNIQUE KEY `unique`(`entry_id`)
 				) TYPE=MyISAM
 			");
 		}

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -18,7 +18,7 @@
 		</author>
 	</authors>
 	<releases>
-		<release version="2.3.0" date="2015-08-11" min="2.5" max="2.6.x">
+		<release version="2.3.0" date="2015-09-01" min="2.5" max="2.6.x">
 			- Added filtered ordering
 			- Bug fixes
 		</release>

--- a/fields/field.order_entries.php
+++ b/fields/field.order_entries.php
@@ -185,7 +185,10 @@
 					))
 				);
 
+				$text = new XMLElement('p', __('Filtered Ordering is an advanced use case for Order Entries. Refer to the readme for further details. Do not select any field unless you understand what it entails as it might lead to unexpected results.'), array('class' => 'help'));
+
 				$fieldset->appendChild($label);
+				$fieldset->appendChild($text);
 
 			}
 			
@@ -413,7 +416,7 @@
 			$filters = $orderEntriesExtension->getFilters($filterableFields,$section_id);
 
 			// if there are no filter, bail out
-			if (empty($filters)) {
+			if (empty($filterableFields)) {
 				return $data['value'];
 			}
 

--- a/fields/field.order_entries.php
+++ b/fields/field.order_entries.php
@@ -40,14 +40,15 @@
 		function processRawFieldData($data, &$status, &$message = null, $simulate = false, $entry_id = null) {
 			$status = self::__OK__;
 			$increment_subsequent_order = false;
-
-			$filters = Symphony::Database()->fetchCol('Field',
-				"SHOW COLUMNS FROM tbl_entries_data_{$this->get('id')} WHERE Field like 'field_%';"
-			);
 			
 			if ($entry_id != null) {
 				$entry_id = General::intval($entry_id);
 			}
+		
+			if (is_array($data)){
+				//TODO Auto Increment for filtered ordering for now just return the data as it is already properly formatted
+				return $data;
+			} 
 
 			if($entry_id) {
 				$new_value = $data;
@@ -278,29 +279,47 @@
 		function displayPublishPanel(&$wrapper, $data = null, $flagWithError = null, $fieldnamePrefix = null, $fieldnamePostfix = null) {
 			$value = $this->getOrderValue($data);
 
-			$label = Widget::Label($this->get('label'));
-			if($this->get('required') != 'yes') $label->appendChild(new XMLElement('i', __('Optional')));
-
 			$max_position = Symphony::Database()->fetchRow(0, "SELECT max(value) AS max FROM tbl_entries_data_{$this->get('id')}");
 
-			$input = Widget::Input(
-				'fields' . $fieldnamePrefix . '[' . $this->get('element_name') . ']' . $fieldnamePostfix,
-				(strlen($value) !== 0 ? (string)$value : (string)++$max_position["max"]),
-				($this->get('hide') == 'yes') ? 'hidden' : 'text'
-			);
+			$inputs = new XMLElement('div');
 
-			if($this->get('hide') != 'yes') {
-				$label->appendChild($input);
-				if($flagWithError != null) {
-					$wrapper->appendChild(Widget::wrapFormElementWithError($label, $flagWithError));
+			// If data is an array there must be filtered values
+			if (is_array($data)){
+				foreach ($data as $col => $row) {
+					foreach ($row as $key => $value) {
+						$input = Widget::Input(
+							'fields' . $fieldnamePrefix . '[' . $this->get('element_name') . '][' . $col . '][' . $key . ']' . $fieldnamePostfix,
+							(strlen($value) !== 0 ? (string)$value : (string)++$max_position["max"]),
+							($this->get('hide') == 'yes' || $col != 'value') ? 'hidden' : 'text'
+						);
+						$inputs->appendChild($input);
+					}
+				}
+				// for now hide all 
+				$wrapper->addClass('irrelevant');
+				$wrapper->appendChild($inputs);
+			} else {
+				$input = Widget::Input(
+					'fields' . $fieldnamePrefix . '[' . $this->get('element_name') . ']' . $fieldnamePostfix,
+					(strlen($value) !== 0 ? (string)$value : (string)++$max_position["max"]),
+					($this->get('hide') == 'yes') ? 'hidden' : 'text'
+				);
+
+				if($this->get('hide') != 'yes') {
+					$label = Widget::Label($this->get('label'));
+					if($this->get('required') != 'yes') $label->appendChild(new XMLElement('i', __('Optional')));
+					$label->appendChild($input);
+					if($flagWithError != null) {
+						$wrapper->appendChild(Widget::wrapFormElementWithError($label, $flagWithError));
+					}
+					else {
+						$wrapper->appendChild($label);
+					}
 				}
 				else {
-					$wrapper->appendChild($label);
+					$wrapper->addClass('irrelevant');
+					$wrapper->appendChild($input);
 				}
-			}
-			else {
-				$wrapper->addClass('irrelevant');
-				$wrapper->appendChild($input);
 			}
 		}
 
@@ -321,7 +340,13 @@
 			}
 
 			// Check type
-			if(strlen($data) > 0 && !is_numeric($data)) {
+			if(is_array($data) && is_array($data['value'])){
+				$numeric = array_filter($data['value'],'is_numeric');
+				if (sizeof($numeric) != sizeof($data['value'])){
+					$message = __('Must be a number.');
+					return self::__INVALID_FIELDS__;					
+				}
+			} else if(strlen($data) > 0 && !is_numeric($data)) {
 				$message = __('Must be a number.');
 				return self::__INVALID_FIELDS__;
 			}

--- a/fields/field.order_entries.php
+++ b/fields/field.order_entries.php
@@ -419,7 +419,7 @@
 
 			if (!is_array($data['value'])){
 				foreach ($data as $key => $value) {
-					$data[$key] = array($value);
+					$data[$key] = array(strtolower(General::sanitize($value)));
 				}
 			}
 

--- a/fields/field.order_entries.php
+++ b/fields/field.order_entries.php
@@ -44,7 +44,7 @@
 			if ($entry_id != null) {
 				$entry_id = General::intval($entry_id);
 			}
-		
+
 			if (is_array($data)){
 				//TODO Auto Increment for filtered ordering for now just return the data as it is already properly formatted
 				return $data;
@@ -284,8 +284,11 @@
 			$inputs = new XMLElement('div');
 
 			// If data is an array there must be filtered values
-			if (is_array($data)){
+			if (is_array($data) && !empty($data)){
 				foreach ($data as $col => $row) {
+					if (!is_array($row)){
+						$row = array($row);
+					}
 					foreach ($row as $key => $value) {
 						$input = Widget::Input(
 							'fields' . $fieldnamePrefix . '[' . $this->get('element_name') . '][' . $col . '][' . $key . ']' . $fieldnamePostfix,


### PR DESCRIPTION
@nitriques / @animaux can you please check to see if these changes make any difference to the ordering on your end. Please note that this could have some adverse impact in the sense if ordering was coming out incorrectly before it might not necessarily fix it, but might put the XML value with the same order as it appeared in the XML order/sorting. I can confirm values now appear consistent at least when filters are applied. Suggestion is to try on a demo/local copy for feedback. 