### PR TITLE
do not set a value for null filters

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -18,8 +18,14 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="2.3.2" date="2015-11-20" min="2.5" max="2.6.x">
+			- Fix bug where value was also being set for null filters
+		</release>
 		<release version="2.3.1" date="2015-10-07" min="2.5" max="2.6.x">
 			- Bug fixes (#69, #72, #73)
+		</release>
+		<release version="2.3.2" date="2015-11-20" min="2.5" max="2.6.x">
+			- Fix bug where value was also being set for null filters
 		</release>
 		<release version="2.3.0" date="2015-09-01" min="2.5" max="2.6.x">
 			- Added filtered ordering

--- a/fields/field.order_entries.php
+++ b/fields/field.order_entries.php
@@ -299,7 +299,7 @@
 					foreach ($row as $key => $value) {
 						$input = Widget::Input(
 							'fields' . $fieldnamePrefix . '[' . $this->get('element_name') . '][' . $col . '][' . $key . ']' . $fieldnamePostfix,
-							(strlen($value) !== 0 ? (string)$value : (string)++$max_position["max"]),
+							(strlen($value) !== 0 || $col != 'value') ? (string)$value : (string)++$max_position["max"],
 							($this->get('hide') == 'yes' || $col != 'value') ? 'hidden' : 'text'
 						);
 						$inputs->appendChild($input);


### PR DESCRIPTION
@nitriques I'm running this on production today so will get back with feedback.

Had a complaint from the client that the site was throwing 500s regularly, when resaving an entry with a filtered order entries field. ( I don't know why it took them that long to report ) the issue seems to be that the 'unfiltered' view was getting a sort order, and on re-saving the filter was being changed with a value - so it could have created issues on at least 2 levels.

1. Filters were screwed up as the null filters were changed with a value.
2. Null filters were given a value, which saved once or twice were throwing a 500 as the unique constraint was broken.

The changes seem to fix the above scenarios will give a go ahead once all is clear in production in case there are any related issues which need to be sorted out.