### PR TITLE
Use new widget error function and delegate

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -15,7 +15,7 @@
 			return array(
 				array(
 					'page' => '/backend/',
-					'delegate' => 'InitaliseAdminPageHead',
+					'delegate' => 'InitialiseAdminPageHead',
 					'callback' => 'prepareIndex'
 				),
 				array(

--- a/fields/field.order_entries.php
+++ b/fields/field.order_entries.php
@@ -320,7 +320,7 @@
 					if($this->get('required') != 'yes') $label->appendChild(new XMLElement('i', __('Optional')));
 					$label->appendChild($input);
 					if($flagWithError != null) {
-						$wrapper->appendChild(Widget::wrapFormElementWithError($label, $flagWithError));
+						$wrapper->appendChild(Widget::Error($label, $flagWithError));
 					}
 					else {
 						$wrapper->appendChild($label);


### PR DESCRIPTION
`Widget::wrapFormElementWithError` has been removed in Symphony 2.4 according to the migration guide.

Also, the mistyped delegate `InitaliseAdminPageHead` should not be used anymore since Symphony 2.4.