### PR TITLE
refactor: Remove unnecessary require_once() statement

### DIFF
--- a/content/content.save.php
+++ b/content/content.save.php
@@ -1,7 +1,5 @@
 <?php
 
-	require_once(TOOLKIT . '/class.jsonpage.php');
-
 	Class contentExtensionOrder_entriesSave extends JSONPage{
 		
 		public function view(){


### PR DESCRIPTION
Since Symphony uses a composer classmap autoloader for all classes in `/lib` (see, [composer.json#L23](https://github.com/symphonycms/symphonycms/blob/68f44f0c36ad3345068676bfb8a61c2e6a2e51f4/composer.json#L23)), this commit removes the redundant `require_once` statement. Doing so avoids code breaking if `JSONPage` is ever moved or the file is renamed.